### PR TITLE
Updated README-No longer suggest BindConfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ services.AddHttpClient("MyClient").AddClientCredentialsHandler(configuration.Get
 
 // Method 3: Lazily bind the options to a configuration section
 services.AddHttpClient("MyClient").AddClientCredentialsHandler();
-services.AddOptions<ClientCredentialsOptions>("MyClient").BindConfiguration(configSectionPath: "MyConfigSection");
+services.AddOptions<ClientCredentialsOptions>("MyClient").Bind(configuration.GetRequiredSection("MyConfigSection"));
 
 // appsettings.json:
 {


### PR DESCRIPTION
As an IDP developer, I want our readme to be a good reference for examples.

COS:
- Update readmes to not recommend using the `BindConfiguration()`
- Recommend `Bind()` instead