### PR TITLE
[IDP-738] Set AuthenticationType, enforce issuer and audience validation, support .NET 8

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "7.0.404",
+    "version": "8.0.100",
     "rollForward": "latestMinor",
     "allowPrerelease": false
   }

--- a/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/AuthenticationBuilderExtensions.cs
+++ b/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/AuthenticationBuilderExtensions.cs
@@ -39,16 +39,17 @@ public static class AuthenticationBuilderExtensions
 
         builder.AddJwtBearer(authScheme, configureOptions);
 
-        var tokenHandlerNamedConfigureOptionsAlreadyAdded = builder.Services.Any(x => IsDescriptorOfJwtBearerOptionsValidator(x, authScheme));
-        if (!tokenHandlerNamedConfigureOptionsAlreadyAdded)
+        var areNamedSingletonsAlreadyRegistered = builder.Services.Any(x => IsNamedJwtBearerOptionsValidatorAlreadyRegistered(x, authScheme));
+        if (!areNamedSingletonsAlreadyRegistered)
         {
             builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IValidateOptions<JwtBearerOptions>>(new JwtBearerOptionsValidator(authScheme)));
+            builder.Services.TryAddEnumerable(ServiceDescriptor.Singleton<IPostConfigureOptions<JwtBearerOptions>>(new ClientCredentialsPostConfigureOptions(authScheme)));
         }
 
         return builder;
     }
 
-    private static bool IsDescriptorOfJwtBearerOptionsValidator(ServiceDescriptor serviceDescriptor, string name)
+    private static bool IsNamedJwtBearerOptionsValidatorAlreadyRegistered(ServiceDescriptor serviceDescriptor, string name)
     {
         return serviceDescriptor.ServiceType == typeof(IValidateOptions<JwtBearerOptions>)
                && serviceDescriptor.ImplementationInstance is JwtBearerOptionsValidator configureOptions

--- a/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/ClientCredentialsDefaults.cs
+++ b/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/ClientCredentialsDefaults.cs
@@ -4,6 +4,8 @@ public static class ClientCredentialsDefaults
 {
     public const string AuthenticationScheme = "ClientCredentials";
 
+    internal const string AuthenticationType = "ClientCredentials";
+
     internal const string AuthorizationReadPolicy = "ClientCredentialsRead";
 
     internal const string AuthorizationWritePolicy = "ClientCredentialsWrite";

--- a/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/ClientCredentialsPostConfigureOptions.cs
+++ b/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/ClientCredentialsPostConfigureOptions.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.Extensions.Options;
+
+namespace Workleap.AspNetCore.Authentication.ClientCredentialsGrant;
+
+internal sealed class ClientCredentialsPostConfigureOptions : IPostConfigureOptions<JwtBearerOptions>
+{
+    private readonly string _authScheme;
+
+    public ClientCredentialsPostConfigureOptions(string authScheme)
+    {
+        this._authScheme = authScheme;
+    }
+
+    public void PostConfigure(string? name, JwtBearerOptions options)
+    {
+        if (name == this._authScheme)
+        {
+            // Default is "AuthenticationTypes.Federation". With this one we can now distinguish identities created by our library
+            options.TokenValidationParameters.AuthenticationType = ClientCredentialsDefaults.AuthenticationType;
+
+            // Since .NET 7, there's a breaking change where the default value "true" is changed to "false" if the developer
+            // defines a non-empty built-in ASP.NET Core configuration section "Authentication:Schemes:<AuthenticationScheme>".
+            // See: https://github.com/dotnet/aspnetcore/blob/v7.0.0/src/Security/Authentication/JwtBearer/src/JwtBearerConfigureOptions.cs#L74-L76
+            options.TokenValidationParameters.ValidateAudience = true;
+            options.TokenValidationParameters.ValidateIssuer = true;
+        }
+    }
+}

--- a/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/Workleap.AspNetCore.Authentication.ClientCredentialsGrant.csproj
+++ b/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/Workleap.AspNetCore.Authentication.ClientCredentialsGrant.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" Condition=" '$(TargetFramework)' == 'net7.0' " />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" Condition=" '$(TargetFramework)' == 'net8.0' " />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/AuthorizationExtensionsTest.cs
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/AuthorizationExtensionsTest.cs
@@ -10,7 +10,7 @@ namespace Workleap.Authentication.ClientCredentialsGrant.Tests;
 public class AuthorizationExtensionsTest
 {
     private const string DefaultAudience = "serviceA";
-    private const string DefaultAuthority = "Https://authority.io";
+    private const string DefaultAuthority = "Https://authority";
 
     [Fact]
     public void GivenNullIServiceCollection_WhenAddClientCredentialsAuthorization_ThenThrowArgumentNullException()

--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/AuthorizationExtensionsTest.cs
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/AuthorizationExtensionsTest.cs
@@ -10,7 +10,7 @@ namespace Workleap.Authentication.ClientCredentialsGrant.Tests;
 public class AuthorizationExtensionsTest
 {
     private const string DefaultAudience = "serviceA";
-    private const string DefaultAuthority = "Https://authority";
+    private const string DefaultAuthority = "https://authority";
 
     [Fact]
     public void GivenNullIServiceCollection_WhenAddClientCredentialsAuthorization_ThenThrowArgumentNullException()

--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/Workleap.Authentication.ClientCredentialsGrant.Tests.csproj
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/Workleap.Authentication.ClientCredentialsGrant.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <SignAssembly>true</SignAssembly>
@@ -18,6 +18,7 @@
     <PackageReference Include="FakeItEasy" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
     <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="7.0.0" Condition=" '$(TargetFramework)' == 'net7.0' " />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" Condition=" '$(TargetFramework)' == 'net8.0' " />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.6.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">

--- a/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/BackchannelRetryHttpMessageHandler.cs
+++ b/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/BackchannelRetryHttpMessageHandler.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.Http;
 using Polly;
 using Polly.Contrib.WaitAndRetry;
 using Polly.Extensions.Http;
+using Polly.Retry;
 
 namespace Workleap.Extensions.Http.Authentication.ClientCredentialsGrant;
 
@@ -21,7 +22,7 @@ internal sealed class BackchannelRetryHttpMessageHandler : PolicyHttpMessageHand
 
     // Microsoft documentation about resilient HTTP requests and production-grade retry jitter strategy:
     // https://learn.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/implement-http-call-retries-exponential-backoff-polly#add-a-jitter-strategy-to-the-retry-policy
-    private static IAsyncPolicy<HttpResponseMessage> GetRetryPolicy()
+    private static AsyncRetryPolicy<HttpResponseMessage> GetRetryPolicy()
     {
         var delay = Backoff.DecorrelatedJitterBackoffV2(medianFirstRetryDelay: TimeSpan.FromSeconds(1), retryCount: 3);
 


### PR DESCRIPTION
* Set `AuthenticationType` to `ClientCredentials` so it can be easily distinguished in ASP.NET Core identities
* Enforce issuer and audience validation due to a breaking change in .NET 7
* Added support for .NET 8