### PR TITLE
Lock Duende.IdentityServer to v6

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,6 +37,14 @@
     {
       "matchManagers": ["github-actions"],
       "groupName": "Pipeline dependencies"
+    },
+    {
+      "matchManagers": ["nuget"],
+      "matchPackageNames": ["Duende.IdentityServer"],
+      "groupName": "Duende.IdentityServer",
+      "description": "Only stay at v6 to keep support of .NET 6",
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ],
   "vulnerabilityAlerts": {


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes

Lock Duende.IdentityServer to v6 to keep support of .NET6

## Breaking changes
NA
