### PR TITLE
[IDP-510] Set a blanket AnalysisLevel to latest-All and address warnings/errors

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -8,6 +8,7 @@
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
+    <AnalysisLevel>latest-All</AnalysisLevel>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 

--- a/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/AuthenticationBuilderExtensions.cs
+++ b/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/AuthenticationBuilderExtensions.cs
@@ -21,10 +21,7 @@ public static class AuthenticationBuilderExtensions
 
     public static AuthenticationBuilder AddClientCredentials(this AuthenticationBuilder builder, string authScheme, Action<JwtBearerOptions> configureOptions)
     {
-        if (builder == null)
-        {
-            throw new ArgumentNullException(nameof(builder));
-        }
+        ArgumentNullException.ThrowIfNull(builder);
 
         builder.Services.AddOptions<JwtBearerOptions>(authScheme).Configure<IConfiguration>((options, configuration) =>
         {

--- a/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/AuthorizationExtensions.cs
+++ b/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/AuthorizationExtensions.cs
@@ -17,10 +17,7 @@ public static class AuthorizationExtensions
 
     public static IServiceCollection AddClientCredentialsAuthorization(this IServiceCollection services)
     {
-        if (services == null)
-        {
-            throw new ArgumentNullException(nameof(services));
-        }
+        ArgumentNullException.ThrowIfNull(services);
 
         services.AddAuthorization();
         services.AddOptions<AuthorizationOptions>()

--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/IntegrationTests.cs
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/IntegrationTests.cs
@@ -135,7 +135,9 @@ public class IntegrationTests
         finally
         {
             // Shut down the web app
+#pragma warning disable CA1849 // Given that we are using .Net6/7/8, updating the method to CancelAsync would break backwards compatibility
             cts.Cancel();
+#pragma warning restore CA1849
         }
     }
 


### PR DESCRIPTION
## Description of changes
We want to apply a code analysis of the latest .NET version used in the project. We can achieve this by adding an analysis level of latest-All.

## Breaking changes
None, we built the project with the AnalysisLevel and there are no new errors.

## Additional checks

Temporarily added property below for testing by building with diagnostics:
```
<ReportAnalyzer>true</ReportAnalyzer>
```
![image](https://github.com/gsoft-inc/wl-authentication-clientcredentialsgrant/assets/158102624/2c8876d4-1200-48e0-bad4-28c92219c161)
