### PR TITLE
Default longer refresh interval for jwtBearerOptions

### DIFF
--- a/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/AuthenticationBuilderExtensions.cs
+++ b/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/AuthenticationBuilderExtensions.cs
@@ -35,6 +35,10 @@ public static class AuthenticationBuilderExtensions
             }
 
             configSection.Bind(options);
+
+            // The default interval is 5 minutes which seemed to cause a lot of traffic to the authority server.
+            // Users still have the possibility to overwrite this value in their services.
+            options.RefreshInterval = TimeSpan.FromHours(12);
         });
 
         builder.AddJwtBearer(ClientCredentialsDefaults.AuthenticationScheme, configureOptions);

--- a/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/AuthenticationBuilderExtensions.cs
+++ b/src/Workleap.AspNetCore.Authentication.ClientCredentialsGrant/AuthenticationBuilderExtensions.cs
@@ -36,7 +36,7 @@ public static class AuthenticationBuilderExtensions
 
             configSection.Bind(options);
 
-            // The default interval is 5 minutes which seemed to cause a lot of traffic to the authority server.
+            // The default interval is 5 minutes which caused a lot of traffic to the authority server.
             // Users still have the possibility to overwrite this value in their services.
             options.RefreshInterval = TimeSpan.FromHours(12);
         });

--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/AuthenticationBuilderExtensionsTests.cs
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/AuthenticationBuilderExtensionsTests.cs
@@ -29,6 +29,7 @@ public class AuthenticationBuilderExtensionsTests
 
         Assert.Equal("audience", jwtBearerOptions.Audience);
         Assert.Equal("https://identity.local", jwtBearerOptions.Authority);
+        Assert.Equal(TimeSpan.FromHours(12), jwtBearerOptions.RefreshInterval);
     }
 
     [Fact]
@@ -42,6 +43,7 @@ public class AuthenticationBuilderExtensionsTests
         {
             option.Authority = "https://identity.local";
             option.Audience = "audience";
+            option.RefreshInterval = TimeSpan.FromMinutes(45);
         });
 
         var sp = services.BuildServiceProvider();
@@ -50,6 +52,7 @@ public class AuthenticationBuilderExtensionsTests
 
         Assert.Equal("audience", jwtBearerOptions.Audience);
         Assert.Equal("https://identity.local", jwtBearerOptions.Authority);
+        Assert.Equal(TimeSpan.FromMinutes(45), jwtBearerOptions.RefreshInterval);
     }
 
     [Fact]


### PR DESCRIPTION
<!-- Please fill out any relevant sections and remove those that don't apply -->

## Description of changes
Changed the default refreshInterval of JwtBearerOptions from 5 minutes to 12 hours in order to reduce the amount of times we go and fetch the OIDC configuration which was causing latency issues for some services.

## Breaking changes
There shouldn't be any.

## Additional checks
<!-- Please check what applies. Note that some of these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
