### PR TITLE
[IDP-1767] Do not enforce HTTPS when clients communicate with servers by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ services.AddOptions<ClientCredentialsOptions>("MyClient").Bind(configuration.Get
 services.AddHttpClient<MyClient>().AddClientCredentialsHandler( /* [...] */);
 ```
 
-Note on `EnforceHttps`.
-It is possible to allow http authenticated requests, however, this should be limited to exceptional scenarios.
+Note on `EnforceHttps`, which is disabled by default.
+It is possible to allow http authenticated requests, however, this should be limited to specific scenarios, such as intra-cluster communication.
 It is strongly advised that you always use https for authenticated requests transmitted as the token sent will be in clear.
 
 Then, instantiate the `HttpClient` later on using `IHttpClientFactory` or directly inject it in the constructor if you used the generic registration:

--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/ClientCredentialsTokenHttpMessageHandlerTests.cs
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/ClientCredentialsTokenHttpMessageHandlerTests.cs
@@ -46,8 +46,9 @@ public sealed class ClientCredentialsTokenHttpMessageHandlerTests : IDisposable
     }
 
     [Fact]
-    public async Task Throws_ClientCredentialsException_When_Http_By_Default()
+    public async Task Throws_ClientCredentialsException_When_Https_Enforced_But_Request_Is_Http()
     {
+        this._options.EnforceHttps = true;
         await Assert.ThrowsAsync<ClientCredentialsException>(() => this._clientCredentialsHttpClient.GetStringAsync("http://whatever", CancellationToken.None));
     }
 

--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/ClientCredentialsTokenHttpMessageHandlerTests.cs
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/ClientCredentialsTokenHttpMessageHandlerTests.cs
@@ -54,7 +54,6 @@ public sealed class ClientCredentialsTokenHttpMessageHandlerTests : IDisposable
     [Fact]
     public async Task SendAsync_When_EnforceHttps_False_For_Http_Requests()
     {
-        this._options.EnforceHttps = false;
         this._mockPrimaryHttpMessageHandler.ExpectedHttpResponseMessages = new[]
         {
             new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("Access granted on first try") },

--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/IntegrationTests.cs
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/IntegrationTests.cs
@@ -104,6 +104,7 @@ public class IntegrationTests
                 options.ClientSecret = "invoices_read_client_secret";
                 options.Scope = $"{Audience}:read";
                 options.CacheLifetimeBuffer = tokenCacheLifetimeBuffer;
+                options.EnforceHttps = true;
             });
 
         // Here begins ASP.NET Core middleware pipelines registration

--- a/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/ClientCredentialsOptions.cs
+++ b/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/ClientCredentialsOptions.cs
@@ -53,9 +53,9 @@ public sealed class ClientCredentialsOptions
     internal string CacheKey { get; set; } = string.Empty;
 
     /// <summary>
-    /// Enforce https for all authenticated requests
+    /// Enforce https for all authenticated requests. Default value is false.
     /// </summary>
-    public bool EnforceHttps { get; set; } = true;
+    public bool EnforceHttps { get; set; }
 
     /// <summary>
     /// When set to true, the library will attempt to acquire a token on app startup,


### PR DESCRIPTION
## Description of changes
See corresponding internal issue.

## Breaking changes
Property `ClientCredentialsOptions.EnforceHttps` is not set by default to `false` instead of `true`.

## Additional checks

- [x] Updated the documentation of the project to reflect the changes
- [x] Added new tests that cover the code changes
