### PR TITLE
[IDP-1955] Adding logging and tracing for better troubleshooting

### DIFF
--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/ClientCredentialsTokenCacheTests.cs
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/ClientCredentialsTokenCacheTests.cs
@@ -4,6 +4,7 @@ using FakeItEasy;
 using Workleap.Extensions.Http.Authentication.ClientCredentialsGrant;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 
 namespace Workleap.Authentication.ClientCredentialsGrant.Tests;
@@ -37,7 +38,7 @@ public class ClientCredentialsTokenCacheTests
         var optionsMonitor = A.Fake<IOptionsMonitor<ClientCredentialsOptions>>();
         A.CallTo(() => optionsMonitor.Get(A<string>._)).ReturnsLazily((string name) => namedOptions.GetOrAdd(name, _ => new ClientCredentialsOptions()));
 
-        this._tokenCache = new ClientCredentialsTokenCache(this._memoryCache, this._distributedCache, this._tokenSerializer, optionsMonitor);
+        this._tokenCache = new ClientCredentialsTokenCache(this._memoryCache, this._distributedCache, this._tokenSerializer, optionsMonitor, new NullLogger<ClientCredentialsTokenCache>());
     }
 
     [Fact]

--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/ClientCredentialsTokenTests.cs
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/ClientCredentialsTokenTests.cs
@@ -1,0 +1,19 @@
+﻿using System.Globalization;
+using Workleap.Extensions.Http.Authentication.ClientCredentialsGrant;
+
+namespace Workleap.Authentication.ClientCredentialsGrant.Tests;
+
+public class ClientCredentialsTokenTests
+{
+    [Theory]
+    [InlineData("2024-01-10", "2024-01-09", 0)]
+    [InlineData("2024-01-10", "2024-01-11", 1)]
+    public void GetTimeToLive_Works(string nowStr, string expirationStr, int expectedTimeToLiveInDays)
+    {
+        var now = DateTimeOffset.ParseExact(nowStr, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var expiration = DateTimeOffset.ParseExact(expirationStr, "yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        var token = new ClientCredentialsToken("dummy", expiration);
+        Assert.Equal(TimeSpan.FromDays(expectedTimeToLiveInDays), token.GetTimeToLive(now));
+    }
+}

--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/IntegrationTests.cs
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/IntegrationTests.cs
@@ -1,278 +1,156 @@
-using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Net;
-using Duende.IdentityServer.Models;
-using Duende.IdentityServer.Stores;
-using Workleap.AspNetCore.Authentication.ClientCredentialsGrant;
 using Workleap.Extensions.Http.Authentication.ClientCredentialsGrant;
-using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Builder;
-using Microsoft.AspNetCore.DataProtection;
-using Microsoft.AspNetCore.Hosting.Server;
-using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Secret = Duende.IdentityServer.Models.Secret;
+using Microsoft.Extensions.Options;
 
 namespace Workleap.Authentication.ClientCredentialsGrant.Tests;
 
-public class IntegrationTests
+public sealed partial class IntegrationTests(ITestOutputHelper testOutputHelper) : IAsyncLifetime
 {
-    private const string Audience = "invoices";
+    // Reused in-memory cache across the multipe web app instances to simulate a distributed system
+    private readonly MemoryDistributedCache _sharedDistributedCache = new(Options.Create(new MemoryDistributedCacheOptions()));
 
-    private readonly ITestOutputHelper _testOutputHelper;
+    // Prevents the test from hanging forever in case of misconfiguration
+    private readonly CancellationTokenSource _timeout = Debugger.IsAttached
+        ? new CancellationTokenSource()
+        : new CancellationTokenSource(TimeSpan.FromMinutes(1));
 
-    public IntegrationTests(ITestOutputHelper testOutputHelper)
+    private WebApplication _idp = null!;
+    private WebApplication _api1 = null!;
+    private WebApplication _api2 = null!;
+
+    private int _tokenRequestCount;
+
+    public async Task InitializeAsync()
     {
-        this._testOutputHelper = testOutputHelper;
+        // Setup IdentityServer as the identity provider
+        this._idp = this.CreateTestIdentityProvider();
+        await this._idp.StartAsync(this._timeout.Token);
+
+        // Creating multiple test APIs helps simulate a distributed system with multiple replicas
+        this._api1 = this.CreateTestApi("app1", this._idp);
+        this._api2 = this.CreateTestApi("app2", this._idp);
+
+        // Ensure that registered clients get cached tokens on app startup
+        await this._api1.StartAsync(this._timeout.Token);
+        await this._api1.Services.GetRequiredService<OnStartupTokenCacheBackgroundService>().WaitForTokenCachingToCompleteAsync(this._timeout.Token);
+
+        await this._api2.StartAsync(this._timeout.Token);
+        await this._api2.Services.GetRequiredService<OnStartupTokenCacheBackgroundService>().WaitForTokenCachingToCompleteAsync(this._timeout.Token);
+
+        // TODO improve background token acquisition so that 2nd app uses the token cached by the 1st app from the distributed cache
+        Assert.Equal(2, this._tokenRequestCount);
     }
 
     [Fact]
-    public async Task Real_Client_Server_Communication()
+    public async Task GivenAnonymousEndpoint_WhenReadAuthenticatedHttpRequest_ShouldBeSuccessful()
     {
-        // Define some OAuth 2.0 scopes for fictional invoices access management
-        var identityApiScopes = new[]
-        {
-            new ApiScope($"{Audience}:read", "Reads your invoices."),
-            new ApiScope($"{Audience}:pay", "Pays your invoices."),
-        };
-
-        // Define the protected resources, here an invoice API (represents something we want to communicate with)
-        var identityApiResources = new[]
-        {
-            new ApiResource(Audience, "Invoice API") { Scopes = { $"{Audience}:read", $"{Audience}:pay" } },
-        };
-
-        var tokenLifetime = TimeSpan.FromSeconds(12);
-        var tokenCacheLifetimeBuffer = TimeSpan.FromSeconds(3); // token will be evicted from cache prior to its expiration
-
-        // Define the OAuth 2.0 clients and the scopes that can be granted
-        var identityOAuthClients = new[]
-        {
-            // This client only allows to read invoices
-            new Client
-            {
-                ClientId = "invoices_read_client",
-                ClientSecrets = new[] { new Secret("invoices_read_client_secret".Sha256()) },
-                AllowedGrantTypes = GrantTypes.ClientCredentials,
-                AllowedScopes = { $"{Audience}:read" },
-                AccessTokenLifetime = (int)tokenLifetime.TotalSeconds,
-            },
-        };
-
-        // Build a real but in-memory ASP.NET Core test server that will both act as identity provider (using IdentityServer) and as the protected API that we'll try to access using a authenticated HttpClient
-        var webAppBuilder = WebApplication.CreateBuilder();
-        webAppBuilder.WebHost.UseTestServer(x => x.BaseAddress = new Uri("https://identity.local", UriKind.Absolute));
-
-        // Here begins services registrations in the dependency injection container
-        webAppBuilder.Services.AddLogging(x => x.SetMinimumLevel(LogLevel.Debug).ClearProviders().AddProvider(new XunitLoggerProvider(this._testOutputHelper)));
-        webAppBuilder.Services.AddSingleton<TestServer>(x => (TestServer)x.GetRequiredService<IServer>());
-        webAppBuilder.Services.AddSingleton<TestServerHandler>();
-        webAppBuilder.Services.AddDataProtection().UseEphemeralDataProtectionProvider();
-
-        webAppBuilder.Services.AddIdentityServer()
-            .AddInMemoryClients(identityOAuthClients)
-            .AddInMemoryApiResources(identityApiResources)
-            .AddInMemoryApiScopes(identityApiScopes)
-            .AddSigningKeyStore<InMemorySigningKeyStore>();
-
-        // Create the authorization policy that will be used to protect our invoices endpoints
-        webAppBuilder.Services.AddAuthentication().AddClientCredentials();
-        webAppBuilder.Services.AddOptions<JwtBearerOptions>(ClientCredentialsDefaults.AuthenticationScheme).Configure<TestServerHandler>((options, testServerClient) =>
-        {
-            options.Audience = Audience;
-            options.Authority = "https://identity.local";
-            options.BackchannelHttpHandler = testServerClient;
-        });
-
-        // This invoice authorization policy must be individually applied to endpoints
-        webAppBuilder.Services.AddClientCredentialsAuthorization();
-
-        // Change the primary HTTP message handler of this library to communicate with this in-memory test server without accessing the network
-        webAppBuilder.Services.AddHttpClient(ClientCredentialsConstants.BackchannelHttpClientName)
-            .ConfigurePrimaryHttpMessageHandler(x => x.GetRequiredService<TestServer>().CreateHandler());
-
-        // Configure the authenticated HttpClient used to communicate with the protected invoices endpoint
-        // Also change the primary HTTP message handler to communicate with this in-memory test server without accessing the network
-        const string invoiceReadClientName = "invoices_read_http_client";
-        webAppBuilder.Services.AddHttpClient(invoiceReadClientName)
-            .ConfigurePrimaryHttpMessageHandler(x => x.GetRequiredService<TestServer>().CreateHandler())
-            .AddClientCredentialsHandler(options =>
-            {
-                options.Authority = "https://identity.local";
-                options.ClientId = "invoices_read_client";
-                options.ClientSecret = "invoices_read_client_secret";
-                options.Scope = $"{Audience}:read";
-                options.CacheLifetimeBuffer = tokenCacheLifetimeBuffer;
-            });
-
-        // Here begins ASP.NET Core middleware pipelines registration
-        var webApp = webAppBuilder.Build();
-
-        webApp.UseIdentityServer();
-        webApp.UseAuthorization();
-
-        webApp.MapGet("/public", () => "This endpoint is public").RequireHost("invoice-app.local");
-        webApp.MapGet("/read-invoices", () => "This protected endpoint is for reading invoices").RequireAuthorization(ClientCredentialsDefaults.AuthorizationReadPolicy).RequireHost("invoice-app.local");
-        webApp.MapGet("/pay-invoices", () => "This protected endpoint is for paying invoices").RequireAuthorization(ClientCredentialsDefaults.AuthorizationWritePolicy).RequireHost("invoice-app.local");
-        webApp.MapGet("/read-invoices-granular", () => "This protected endpoint is for reading invoices").RequireClientCredentials("read").RequireHost("invoice-app.local");
-        webApp.MapGet("/pay-invoices-granular", () => "This protected endpoint is for paying invoices").RequireClientCredentials("pay").RequireHost("invoice-app.local");
-
-        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(1));
-
-        try
-        {
-            // Start the web app without blocking, the cancellation token source will make sure it will be shutdown if something wrong happens
-            webApp.RunAsync(cts.Token).Forget();
-
-            try
-            {
-                // Ensure that registered clients get cached tokens on app startup
-                var cachingBackgroundService = webApp.Services.GetRequiredService<OnStartupTokenCacheBackgroundService>();
-                await cachingBackgroundService.WaitForTokenCachingToCompleteAsync(cts.Token);
-            }
-            catch (OperationCanceledException) when (cts.Token.IsCancellationRequested)
-            {
-                throw new TimeoutException($"{nameof(OnStartupTokenCacheBackgroundService)} didn't complete its job in time");
-            }
-
-            // Retrieve the access token from the cache for later comparison
-            // Assert that the token lifetime is set according to the IdentityServer configuration
-            var tokenCache = webApp.Services.GetRequiredService<IClientCredentialsTokenCache>();
-            var tokenAfterStartupBackgroundCaching = await tokenCache.GetAsync(invoiceReadClientName, cts.Token);
-            Assert.NotNull(tokenAfterStartupBackgroundCaching);
-            Assert.InRange(tokenAfterStartupBackgroundCaching.Expiration, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.Add(tokenLifetime));
-
-            var invoicesReadHttpClient = webApp.Services.GetRequiredService<IHttpClientFactory>().CreateClient(invoiceReadClientName);
-
-            // Consuming an anonymous/public endpoint should work
-            var publicEndpointResponse = await invoicesReadHttpClient.GetStringAsync("https://invoice-app.local/public", cts.Token);
-            Assert.Equal("This endpoint is public", publicEndpointResponse);
-
-            // Using the classic policy, reading invoices should be successful because we're authenticated with a JWT that has the "invoices" audience and "invoices.read" scope
-            var readInvoicesResponse = await invoicesReadHttpClient.GetStringAsync("https://invoice-app.local/read-invoices", cts.Token);
-            Assert.Equal("This protected endpoint is for reading invoices", readInvoicesResponse);
-
-            // Using the granular policy, reading invoices should be successful because we're authenticated with a JWT that has the "invoices" audience and "invoices.read" scope
-            var readInvoicesGranularResponse = await invoicesReadHttpClient.GetStringAsync("https://invoice-app.local/read-invoices-granular", cts.Token);
-            Assert.Equal("This protected endpoint is for reading invoices", readInvoicesGranularResponse);
-
-            // Using the classic policy, paying invoices should throw a forbidden HTTP exception because the JWT doesn't have the "invoices.pay" scope
-            var payInvoicesException = await Assert.ThrowsAsync<HttpRequestException>(() => invoicesReadHttpClient.GetStringAsync("https://invoice-app.local/pay-invoices", cts.Token));
-            Assert.Equal(HttpStatusCode.Forbidden, payInvoicesException.StatusCode);
-
-            // Using the granular policy, paying invoices should throw a forbidden HTTP exception because the JWT doesn't have the "invoices.pay" scope
-            var payInvoicesGranularException = await Assert.ThrowsAsync<HttpRequestException>(() => invoicesReadHttpClient.GetStringAsync("https://invoice-app.local/pay-invoices-granular", cts.Token));
-            Assert.Equal(HttpStatusCode.Forbidden, payInvoicesGranularException.StatusCode);
-
-            // We require JWT-authenticated requests to be sent over HTTPS
-            var unsecuredException = await Assert.ThrowsAsync<ClientCredentialsException>(() => invoicesReadHttpClient.GetStringAsync("http://invoice-app.local/public", cts.Token));
-            Assert.Equal("Due to security concerns, authenticated requests must be sent over HTTPS", unsecuredException.Message);
-
-            // Ensure the token is the same than the one we got after the background caching as it should still be valid
-            var tokenAfterAuthenticatedRequest = await tokenCache.GetAsync(invoiceReadClientName, cts.Token);
-            Assert.NotNull(tokenAfterAuthenticatedRequest);
-            Assert.Equal(tokenAfterStartupBackgroundCaching, tokenAfterAuthenticatedRequest);
-
-            // Wait until token is expired - before that, there should be no background refresh
-            var tokenManagementService = webApp.Services.GetRequiredService<ClientCredentialsTokenManagementService>();
-            Assert.Equal(0, tokenManagementService.BackgroundRefreshedTokenCount);
-            await Task.Delay(tokenAfterAuthenticatedRequest.Expiration - DateTimeOffset.UtcNow, cts.Token);
-
-            // At this point we're not making any new authenticated HTTP request,
-            // but a background task should have refreshed the token, which should differ from the initially cached one
-            Assert.Equal(1, tokenManagementService.BackgroundRefreshedTokenCount);
-            var tokenAfterFirstBackgroundRefresh = await tokenCache.GetAsync(invoiceReadClientName, cts.Token);
-            Assert.NotNull(tokenAfterFirstBackgroundRefresh);
-            Assert.NotEqual(tokenAfterStartupBackgroundCaching, tokenAfterFirstBackgroundRefresh);
-
-            // If we wait a little bit longer, the token should be refreshed again
-            await Task.Delay(tokenAfterFirstBackgroundRefresh.Expiration - DateTimeOffset.UtcNow, cts.Token);
-            Assert.Equal(2, tokenManagementService.BackgroundRefreshedTokenCount);
-            var tokenAfterSecondBackgroundRefresh = await tokenCache.GetAsync(invoiceReadClientName, cts.Token);
-            Assert.NotNull(tokenAfterSecondBackgroundRefresh);
-            Assert.NotEqual(tokenAfterFirstBackgroundRefresh, tokenAfterSecondBackgroundRefresh);
-        }
-        finally
-        {
-            // Shut down the web app
-#pragma warning disable CA1849 // Given that we are using .Net6/7/8, updating the method to CancelAsync would break backwards compatibility
-            cts.Cancel();
-#pragma warning restore CA1849
-        }
+        var httpClient = this._api1.Services.GetRequiredService<IHttpClientFactory>().CreateClient(InvoiceReadHttpClientName);
+        var response = await httpClient.GetStringAsync("https://invoice-app.local/anonymous", this._timeout.Token);
+        Assert.Equal("This endpoint is public", response);
     }
 
-    private sealed class TestServerHandler : DelegatingHandler
+    [Fact]
+    public async Task GivenReadEndpointWithClassicPolicy_WhenReadAuthenticatedHttpRequest_ShouldBeSuccessful()
     {
-        private readonly TestServer _testServer;
-        private HttpClient? _testServerClient;
-
-        public TestServerHandler(TestServer testServer)
-        {
-            this._testServer = testServer;
-        }
-
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            this._testServerClient ??= this._testServer.CreateClient();
-
-            // Request has to be cloned since it has already gone through the httpclient wrapping this handler even though the request hasn't been sent yet.
-            var cloneRequest = await CloneHttpRequest(request, cancellationToken);
-
-            return await this._testServerClient.SendAsync(cloneRequest, cancellationToken);
-        }
-
-        private static async Task<HttpRequestMessage> CloneHttpRequest(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            var cloneRequest = new HttpRequestMessage(request.Method, request.RequestUri);
-            cloneRequest.Version = request.Version;
-
-            foreach (var (key, value) in request.Headers)
-            {
-                cloneRequest.Headers.TryAddWithoutValidation(key, value);
-            }
-
-            foreach (var (key, value) in request.Options)
-            {
-                cloneRequest.Options.TryAdd(key, value);
-            }
-
-            if (request.Content != null)
-            {
-                var contentBytes = await request.Content.ReadAsByteArrayAsync(cancellationToken);
-                cloneRequest.Content = new ByteArrayContent(contentBytes);
-
-                foreach (var (key, value) in request.Content.Headers)
-                {
-                    cloneRequest.Content.Headers.TryAddWithoutValidation(key, value);
-                }
-            }
-
-            return cloneRequest;
-        }
+        var httpClient = this._api1.Services.GetRequiredService<IHttpClientFactory>().CreateClient(InvoiceReadHttpClientName);
+        var response = await httpClient.GetStringAsync("https://invoice-app.local/read-invoices", this._timeout.Token);
+        Assert.Equal("This protected endpoint is for reading invoices", response);
     }
 
-    // Prevents IdentityServer from using the actual file system to store the signing keys
-    // It also reduces the amount of logs, which makes troubleshooting easier
-    private sealed class InMemorySigningKeyStore : ISigningKeyStore
+    [Fact]
+    public async Task GivenReadEndpointWithGranularPolicy_WhenReadAuthenticatedHttpRequest_ShouldBeSuccessful()
     {
-        private readonly ConcurrentDictionary<string, SerializedKey> _keys = new(StringComparer.Ordinal);
+        var httpClient = this._api1.Services.GetRequiredService<IHttpClientFactory>().CreateClient(InvoiceReadHttpClientName);
+        var response = await httpClient.GetStringAsync("https://invoice-app.local/read-invoices-granular", this._timeout.Token);
+        Assert.Equal("This protected endpoint is for reading invoices", response);
+    }
 
-        public Task<IEnumerable<SerializedKey>> LoadKeysAsync()
+    [Fact]
+    public async Task GivenPayEndpointWithClassicPolicy_WhenReadAuthenticatedHttpRequest_ShouldThrowForbiddenHttpException()
+    {
+        var httpClient = this._api1.Services.GetRequiredService<IHttpClientFactory>().CreateClient(InvoiceReadHttpClientName);
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() => httpClient.GetStringAsync("https://invoice-app.local/pay-invoices", this._timeout.Token));
+        Assert.Equal(HttpStatusCode.Forbidden, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task GivenPayEndpointWithGranularPolicy_WhenReadAuthenticatedHttpRequest_ShouldThrowForbiddenHttpException()
+    {
+        var httpClient = this._api1.Services.GetRequiredService<IHttpClientFactory>().CreateClient(InvoiceReadHttpClientName);
+        var ex = await Assert.ThrowsAsync<HttpRequestException>(() => httpClient.GetStringAsync("https://invoice-app.local/pay-invoices-granular", this._timeout.Token));
+        Assert.Equal(HttpStatusCode.Forbidden, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task GivenHttpEndpoint_WhenHttpsIsRequired_ThrowsClientCredentialsException()
+    {
+        var httpClient = this._api1.Services.GetRequiredService<IHttpClientFactory>().CreateClient(InvoiceReadHttpClientName);
+        var ex = await Assert.ThrowsAsync<ClientCredentialsException>(() => httpClient.GetStringAsync("http://invoice-app.local/public", this._timeout.Token));
+        Assert.Equal("Due to security concerns, authenticated requests must be sent over HTTPS", ex.Message);
+    }
+
+    [Fact]
+    public async Task TokenCachingVerification()
+    {
+        // Retrieve the access token from the cache for later comparison
+        // Assert that the token lifetime is set according to the IdentityServer configuration
+        var tokenCache = this._api1.Services.GetRequiredService<IClientCredentialsTokenCache>();
+        var tokenAfterStartupBackgroundCaching = await tokenCache.GetAsync(InvoiceReadHttpClientName, this._timeout.Token);
+        Assert.NotNull(tokenAfterStartupBackgroundCaching);
+        Assert.InRange(tokenAfterStartupBackgroundCaching.Expiration, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.Add(TokenLifetime));
+
+        // Make an authenticated HTTP request to the protected endpoint
+        var api1HttpClient = this._api1.Services.GetRequiredService<IHttpClientFactory>().CreateClient(InvoiceReadHttpClientName);
+        var readInvoicesResponse = await api1HttpClient.GetStringAsync("https://invoice-app.local/read-invoices", this._timeout.Token);
+        Assert.Equal("This protected endpoint is for reading invoices", readInvoicesResponse);
+
+        // Ensure the token is the same than the one we got after the background caching as it should still be valid
+        var tokenAfterAuthenticatedRequest = await tokenCache.GetAsync(InvoiceReadHttpClientName, this._timeout.Token);
+        Assert.NotNull(tokenAfterAuthenticatedRequest);
+        Assert.Equal(tokenAfterStartupBackgroundCaching, tokenAfterAuthenticatedRequest);
+
+        // Wait until token is expired - before that, there should be no background refresh
+        var tokenManagementService = this._api1.Services.GetRequiredService<ClientCredentialsTokenManagementService>();
+        Assert.Equal(0, tokenManagementService.BackgroundRefreshedTokenCount);
+        var timeToLive = tokenAfterAuthenticatedRequest.GetTimeToLive(DateTimeOffset.UtcNow);
+        testOutputHelper.WriteLine(timeToLive.ToString());
+        await Task.Delay(timeToLive, this._timeout.Token);
+
+        // At this point we're not making any new authenticated HTTP request,
+        // but a background task should have refreshed the token, which should differ from the initially cached one
+        Assert.Equal(1, tokenManagementService.BackgroundRefreshedTokenCount);
+        var tokenAfterFirstBackgroundRefresh = await tokenCache.GetAsync(InvoiceReadHttpClientName, this._timeout.Token);
+        Assert.NotNull(tokenAfterFirstBackgroundRefresh);
+        Assert.NotEqual(tokenAfterStartupBackgroundCaching, tokenAfterFirstBackgroundRefresh);
+
+        // If we wait a little bit longer, the token should be refreshed again
+        await Task.Delay(tokenAfterFirstBackgroundRefresh.GetTimeToLive(DateTimeOffset.UtcNow), this._timeout.Token);
+        Assert.Equal(2, tokenManagementService.BackgroundRefreshedTokenCount);
+        var tokenAfterSecondBackgroundRefresh = await tokenCache.GetAsync(InvoiceReadHttpClientName, this._timeout.Token);
+        Assert.NotNull(tokenAfterSecondBackgroundRefresh);
+        Assert.NotEqual(tokenAfterFirstBackgroundRefresh, tokenAfterSecondBackgroundRefresh);
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (this._api2 != null)
         {
-            return Task.FromResult(this._keys.Values.ToArray().AsEnumerable());
+            await this._api2.DisposeAsync();
         }
 
-        public Task StoreKeyAsync(SerializedKey key)
+        if (this._api1 != null)
         {
-            this._keys[key.Id] = key;
-            return Task.CompletedTask;
+            await this._api1.DisposeAsync();
         }
 
-        public Task DeleteKeyAsync(string id)
+        if (this._idp != null)
         {
-            this._keys.TryRemove(id, out _);
-            return Task.CompletedTask;
+            await this._idp.DisposeAsync();
         }
     }
 }

--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/IntegrationTests_Setup.cs
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/IntegrationTests_Setup.cs
@@ -1,0 +1,196 @@
+﻿using System.Collections.Concurrent;
+using Duende.IdentityServer.Models;
+using Duende.IdentityServer.Stores;
+using Workleap.AspNetCore.Authentication.ClientCredentialsGrant;
+using Workleap.Extensions.Http.Authentication.ClientCredentialsGrant;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Secret = Duende.IdentityServer.Models.Secret;
+
+namespace Workleap.Authentication.ClientCredentialsGrant.Tests;
+
+public sealed partial class IntegrationTests
+{
+    private const string InvoicesAudience = "invoices";
+
+    private const string InvoicesReadScope = $"{InvoicesAudience}:read";
+    private const string InvoicesPayScope = $"{InvoicesAudience}:pay";
+
+    private const string InvoicesReadClientId = "invoices_read_client";
+    private const string InvoicesReadClientSecret = "invoices_read_client_secret";
+
+    private const string InvoicesAuthority = "https://identity.local";
+
+    private const string InvoiceReadHttpClientName = "invoices_read_http_client";
+
+    // Tokens will be evicted from cache prior to their expiration
+    private static readonly TimeSpan TokenLifetime = TimeSpan.FromSeconds(12);
+    private static readonly TimeSpan TokenCacheLifetimeBuffer = TimeSpan.FromSeconds(3);
+
+    private WebApplication CreateTestIdentityProvider()
+    {
+        // Define some OAuth 2.0 scopes for fictional invoices access management
+        ApiScope[] identityApiScopes =
+        [
+            new ApiScope(InvoicesReadScope, "Reads your invoices."),
+            new ApiScope(InvoicesPayScope, "Pays your invoices.")
+        ];
+
+        // Define the protected resources, here an invoice API (represents something we want to communicate with)
+        ApiResource[] identityApiResources =
+        [
+            new ApiResource(InvoicesAudience, "Invoice API")
+            {
+                Scopes = [InvoicesReadScope, InvoicesPayScope]
+            }
+        ];
+
+        // Define the OAuth 2.0 clients and the scopes that can be granted
+        Client[] identityOAuthClients =
+        [
+            // This client only allows to read invoices
+            new Client
+            {
+                ClientId = InvoicesReadClientId,
+                ClientSecrets = [new Secret(InvoicesReadClientSecret.Sha256())],
+                AllowedGrantTypes = GrantTypes.ClientCredentials,
+                AllowedScopes = [InvoicesReadScope],
+                AccessTokenLifetime = (int)TokenLifetime.TotalSeconds,
+            }
+        ];
+
+        // Build a real but in-memory ASP.NET Core test server that will both act as identity provider (using IdentityServer) and as the protected API that we'll try to access using a authenticated HttpClient
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseTestServer(x => x.BaseAddress = new Uri(InvoicesAuthority, UriKind.Absolute));
+
+        builder.Logging.SetMinimumLevel(LogLevel.Information);
+        builder.Logging.ClearProviders();
+        builder.Logging.AddProvider(new XunitLoggerProvider(testOutputHelper, "idp"));
+
+        builder.Services.AddDataProtection().UseEphemeralDataProtectionProvider();
+
+        builder.Services.AddIdentityServer()
+            .AddInMemoryClients(identityOAuthClients)
+            .AddInMemoryApiResources(identityApiResources)
+            .AddInMemoryApiScopes(identityApiScopes)
+            .AddSigningKeyStore<InMemorySigningKeyStore>();
+
+        var idp = builder.Build();
+
+        idp.Use(async (context, next) =>
+        {
+            // https://identityserver4.readthedocs.io/en/latest/endpoints/token.html#example
+            const string identityServerTokenEndpoint = "/connect/token";
+
+            if (context.Request.Path == identityServerTokenEndpoint)
+            {
+                Interlocked.Increment(ref this._tokenRequestCount);
+            }
+
+            await next(context);
+        });
+
+        idp.UseIdentityServer();
+
+        return idp;
+    }
+
+    private WebApplication CreateTestApi(string appName, WebApplication idp)
+    {
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.WebHost.UseTestServer();
+
+        builder.Logging.SetMinimumLevel(LogLevel.Debug);
+        builder.Logging.ClearProviders();
+        builder.Logging.AddProvider(new XunitLoggerProvider(testOutputHelper, appName));
+
+        builder.Services.AddSingleton<TestServer>(x => (TestServer)x.GetRequiredService<IServer>());
+        builder.Services.AddDataProtection().UseEphemeralDataProtectionProvider();
+
+        // Create the authorization policy that will be used to protect our invoices endpoints
+        builder.Services.AddAuthentication().AddClientCredentials(options =>
+        {
+            options.Audience = InvoicesAudience;
+            options.Authority = InvoicesAuthority;
+            options.Backchannel = idp.GetTestClient();
+        });
+
+        // This invoice authorization policy must be individually applied to endpoints
+        builder.Services.AddClientCredentialsAuthorization();
+
+        // Change the primary HTTP message handler of this library to communicate with the in-memory IDP server
+        builder.Services.AddHttpClient(ClientCredentialsConstants.BackchannelHttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(() => idp.GetTestServer().CreateHandler());
+
+        // Configure the authenticated HttpClient used to communicate with the protected invoices endpoint
+        // Also change the primary HTTP message handler to communicate with this in-memory test server without accessing the network
+        builder.Services.AddHttpClient(InvoiceReadHttpClientName)
+            .ConfigurePrimaryHttpMessageHandler(x => x.GetRequiredService<TestServer>().CreateHandler())
+            .AddClientCredentialsHandler(options =>
+            {
+                options.Authority = InvoicesAuthority;
+                options.ClientId = InvoicesReadClientId;
+                options.ClientSecret = InvoicesReadClientSecret;
+                options.Scope = InvoicesReadScope;
+                options.CacheLifetimeBuffer = TokenCacheLifetimeBuffer;
+            });
+
+        // Share the same distributed cache among all instances of the test APIs
+        builder.Services.AddSingleton<IDistributedCache>(this._sharedDistributedCache);
+
+        // Here begins ASP.NET Core middleware pipelines registration
+        var api = builder.Build();
+
+        api.UseAuthorization();
+
+        api.MapGet("/anonymous", () => "This endpoint is public")
+            .RequireHost("invoice-app.local");
+
+        api.MapGet("/read-invoices", () => "This protected endpoint is for reading invoices")
+            .RequireAuthorization(ClientCredentialsDefaults.AuthorizationReadPolicy)
+            .RequireHost("invoice-app.local");
+
+        api.MapGet("/pay-invoices", () => "This protected endpoint is for paying invoices")
+            .RequireAuthorization(ClientCredentialsDefaults.AuthorizationWritePolicy)
+            .RequireHost("invoice-app.local");
+
+        api.MapGet("/read-invoices-granular", () => "This protected endpoint is for reading invoices")
+            .RequireClientCredentials("read")
+            .RequireHost("invoice-app.local");
+
+        api.MapGet("/pay-invoices-granular", () => "This protected endpoint is for paying invoices")
+            .RequireClientCredentials("pay")
+            .RequireHost("invoice-app.local");
+
+        return api;
+    }
+
+    // Prevents IdentityServer from using the actual file system to store the signing keys
+    // It also reduces the amount of logs, which makes troubleshooting easier
+    private sealed class InMemorySigningKeyStore : ISigningKeyStore
+    {
+        private readonly ConcurrentDictionary<string, SerializedKey> _keys = new(StringComparer.Ordinal);
+
+        public Task<IEnumerable<SerializedKey>> LoadKeysAsync()
+        {
+            return Task.FromResult(this._keys.Values.ToArray().AsEnumerable());
+        }
+
+        public Task StoreKeyAsync(SerializedKey key)
+        {
+            this._keys[key.Id] = key;
+            return Task.CompletedTask;
+        }
+
+        public Task DeleteKeyAsync(string id)
+        {
+            this._keys.TryRemove(id, out _);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/OpenAPI/OpenApiSecurityDescriptionTests.cs
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/OpenAPI/OpenApiSecurityDescriptionTests.cs
@@ -1,9 +1,10 @@
 using CliWrap;
+using CliWrap.Buffered;
 using Meziantou.Framework;
 
 namespace Workleap.Authentication.ClientCredentialsGrant.Tests.OpenAPI;
 
-public class OpenApiSecurityDescriptionTests
+public class OpenApiSecurityDescriptionTests(ITestOutputHelper testOutputHelper)
 {
     [Fact]
     public async Task Given_API_With_Client_Credentials_Attribute_When_Generating_OpenAPI_Then_Equal_Expected_Document()
@@ -20,7 +21,11 @@ public class OpenApiSecurityDescriptionTests
             .WithWorkingDirectory(projectFolder)
             .WithValidation(CommandResultValidation.None)
             .WithArguments(["build", "--no-incremental"])
-            .ExecuteAsync();
+            .ExecuteBufferedAsync();
+
+        testOutputHelper.WriteLine("Build output:");
+        testOutputHelper.WriteLine(result.StandardError);
+        testOutputHelper.WriteLine(result.StandardOutput);
 
         // Check if the build was successful
         Assert.Equal(0, result.ExitCode);

--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/Workleap.Authentication.ClientCredentialsGrant.Tests.csproj
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/Workleap.Authentication.ClientCredentialsGrant.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <SignAssembly>true</SignAssembly>
@@ -18,8 +18,7 @@
     <PackageReference Include="Duende.IdentityServer" Version="6.3.10" />
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="Meziantou.Framework.FullPath" Version="1.0.13" />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="6.0.32" Condition=" '$(TargetFramework)' == 'net6.0' " />
-    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.7" Condition=" '$(TargetFramework)' == 'net8.0' " />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="8.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">

--- a/src/Workleap.Authentication.ClientCredentialsGrant.Tests/XunitLoggerProvider.cs
+++ b/src/Workleap.Authentication.ClientCredentialsGrant.Tests/XunitLoggerProvider.cs
@@ -3,25 +3,18 @@ using Microsoft.Extensions.Logging;
 
 namespace Workleap.Authentication.ClientCredentialsGrant.Tests;
 
-internal sealed class XunitLoggerProvider : ILoggerProvider, ILogger
+internal sealed class XunitLoggerProvider(ITestOutputHelper testOutput, string appName) : ILoggerProvider, ILogger
 {
     private static readonly Dictionary<LogLevel, string> LogLevelStrings = new Dictionary<LogLevel, string>
     {
-        [LogLevel.None] = "NON",
-        [LogLevel.Trace] = "TRC",
-        [LogLevel.Debug] = "DBG",
-        [LogLevel.Information] = "INF",
-        [LogLevel.Warning] = "WRN",
-        [LogLevel.Error] = "ERR",
-        [LogLevel.Critical] = "CRT",
+        [LogLevel.None] = "none",
+        [LogLevel.Trace] = "trce",
+        [LogLevel.Debug] = "dbug",
+        [LogLevel.Information] = "info",
+        [LogLevel.Warning] = "warn",
+        [LogLevel.Error] = "fail",
+        [LogLevel.Critical] = "crit"
     };
-
-    private readonly ITestOutputHelper _output;
-
-    public XunitLoggerProvider(ITestOutputHelper output)
-    {
-        this._output = output;
-    }
 
     public ILogger CreateLogger(string categoryName)
     {
@@ -32,7 +25,7 @@ internal sealed class XunitLoggerProvider : ILoggerProvider, ILogger
     public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
     {
         var message = formatter(state, exception);
-        this._output.WriteLine("[{0:HH:mm:ss:ffff} {1}] {2}", DateTime.Now, LogLevelStrings[logLevel], message);
+        testOutput.WriteLine("[{0:HH:mm:ss:ffff} {1} {2}] {3}", DateTime.Now, appName, LogLevelStrings[logLevel], message);
     }
 
     public bool IsEnabled(LogLevel logLevel)
@@ -41,9 +34,7 @@ internal sealed class XunitLoggerProvider : ILoggerProvider, ILogger
     }
 
     public IDisposable BeginScope<TState>(TState state)
-#if NET7_0_OR_GREATER
         where TState : notnull
-#endif
     {
         return new NoopDisposable();
     }

--- a/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/ClientCredentialsToken.cs
+++ b/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/ClientCredentialsToken.cs
@@ -10,6 +10,16 @@ namespace Workleap.Extensions.Http.Authentication.ClientCredentialsGrant;
 
 internal sealed class ClientCredentialsToken
 {
+    public ClientCredentialsToken()
+    {
+    }
+
+    public ClientCredentialsToken(string accessToken, DateTimeOffset expiration)
+    {
+        this.AccessToken = accessToken;
+        this.Expiration = expiration;
+    }
+
     [JsonPropertyName("accessToken")]
     public string AccessToken { get; init; } = string.Empty;
 
@@ -19,6 +29,12 @@ internal sealed class ClientCredentialsToken
     private bool Equals(ClientCredentialsToken other)
     {
         return this.AccessToken == other.AccessToken && this.Expiration.Equals(other.Expiration);
+    }
+
+    public TimeSpan GetTimeToLive(DateTimeOffset now)
+    {
+        var timeToLive = this.Expiration - now;
+        return timeToLive > TimeSpan.Zero ? timeToLive : TimeSpan.Zero;
     }
 
     public override bool Equals(object? obj)

--- a/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/ClientCredentialsTokenEndpointService.cs
+++ b/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/ClientCredentialsTokenEndpointService.cs
@@ -1,12 +1,13 @@
 ﻿// This file is based on https://github.com/DuendeSoftware/Duende.AccessTokenManagement/blob/1.1.0/src/Duende.AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
+// This file is based on https://github.com/DuendeSoftware/Duende.AccessTokenManagement/blob/1.1.0/src/Duende.AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
 // Copyright (c) Brock Allen & Dominick Baier, licensed under the Apache License, Version 2.0. All rights reserved.
 //
 // The original file has been significantly modified, and these modifications are Copyright (c) Workleap, 2023.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-using System.Net;
 using System.Text;
 using IdentityModel.Client;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Workleap.Extensions.Http.Authentication.ClientCredentialsGrant;
@@ -19,12 +20,18 @@ internal class ClientCredentialsTokenEndpointService : IClientCredentialsTokenEn
     private readonly IHttpClientFactory _httpClientFactory;
     private readonly IOptionsMonitor<ClientCredentialsOptions> _optionsMonitor;
     private readonly IOpenIdConfigurationRetriever _oidcRetriever;
+    private readonly ILogger<ClientCredentialsTokenEndpointService> _logger;
 
-    public ClientCredentialsTokenEndpointService(IHttpClientFactory httpClientFactory, IOptionsMonitor<ClientCredentialsOptions> optionsMonitor, IOpenIdConfigurationRetriever oidcRetriever)
+    public ClientCredentialsTokenEndpointService(
+        IHttpClientFactory httpClientFactory,
+        IOptionsMonitor<ClientCredentialsOptions> optionsMonitor,
+        IOpenIdConfigurationRetriever oidcRetriever,
+        ILogger<ClientCredentialsTokenEndpointService> logger)
     {
         this._httpClientFactory = httpClientFactory;
         this._optionsMonitor = optionsMonitor;
         this._oidcRetriever = oidcRetriever;
+        this._logger = logger;
     }
 
     public async Task<ClientCredentialsToken> RequestTokenAsync(string clientName, CancellationToken cancellationToken)
@@ -44,7 +51,10 @@ internal class ClientCredentialsTokenEndpointService : IClientCredentialsTokenEn
 
         var httpClient = this._httpClientFactory.CreateClient(ClientCredentialsConstants.BackchannelHttpClientName);
 
-        // Eventually replace IdentityModel with Microsoft.Identity.Client (MSAL) when their generic authority feature is mature
+        this._logger.RequestingNewTokenForClient(options.ClientId);
+
+        // Eventually replace IdentityModel with Microsoft.Identity.Client (MSAL)
+        // https://anthonysimmon.com/replacing-identitymodel-with-msal-oidc-support/
         var response = await httpClient.RequestClientCredentialsTokenAsync(request, cancellationToken).ConfigureAwait(false);
 
         try

--- a/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/ClientCredentialsTokenEndpointService.cs
+++ b/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/ClientCredentialsTokenEndpointService.cs
@@ -1,5 +1,4 @@
 ﻿// This file is based on https://github.com/DuendeSoftware/Duende.AccessTokenManagement/blob/1.1.0/src/Duende.AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
-// This file is based on https://github.com/DuendeSoftware/Duende.AccessTokenManagement/blob/1.1.0/src/Duende.AccessTokenManagement/ClientCredentialsTokenEndpointService.cs
 // Copyright (c) Brock Allen & Dominick Baier, licensed under the Apache License, Version 2.0. All rights reserved.
 //
 // The original file has been significantly modified, and these modifications are Copyright (c) Workleap, 2023.

--- a/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/ClientCredentialsTokenManagementService.cs
+++ b/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/ClientCredentialsTokenManagementService.cs
@@ -53,7 +53,7 @@ internal class ClientCredentialsTokenManagementService : IClientCredentialsToken
     {
         var options = this._optionsMonitor.Get(clientName);
 
-        this._logger.RequestingTokenForClientWithCachingBehavior(options.ClientId, cachingBehavior);
+        this._logger.GettingTokenForClientWithCachingBehavior(options.ClientId, cachingBehavior);
 
         if (cachingBehavior == CachingBehavior.PreferCache)
         {

--- a/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/LoggingExtensions.cs
+++ b/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/LoggingExtensions.cs
@@ -22,8 +22,8 @@ internal static partial class LoggingExtensions
     public static partial void RequestingNewTokenForClient(this ILogger logger, string clientId);
 
     // ClientCredentialsTokenManagementService
-    [LoggerMessage(6, LogLevel.Debug, "Requesting a token for client ID {ClientId} with caching behavior {CachingBehavior}")]
-    public static partial void RequestingTokenForClientWithCachingBehavior(this ILogger logger, string clientId, CachingBehavior cachingBehavior);
+    [LoggerMessage(6, LogLevel.Debug, "Getting a token for client ID {ClientId} with caching behavior {CachingBehavior}")]
+    public static partial void GettingTokenForClientWithCachingBehavior(this ILogger logger, string clientId, CachingBehavior cachingBehavior);
 
     [LoggerMessage(7, LogLevel.Debug, "Scheduling background token refresh for client ID {ClientId} in {Delay}")]
     public static partial void SchedulingBackgroundTokenRefresh(this ILogger logger, string clientId, TimeSpan delay);

--- a/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/LoggingExtensions.cs
+++ b/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/LoggingExtensions.cs
@@ -8,10 +8,10 @@ internal static partial class LoggingExtensions
     [LoggerMessage(1, LogLevel.Debug, "Caching token for client ID {ClientId} with cache key {CacheKey} for {CacheDuration}")]
     public static partial void CachingToken(this ILogger logger, string clientId, string cacheKey, TimeSpan cacheDuration);
 
-    [LoggerMessage(2, LogLevel.Debug, "Successfully read token for client ID {ClientId} from L1 cache with cache key {CacheKey}, will expire in {TimeToLive}")]
+    [LoggerMessage(2, LogLevel.Debug, "Successfully read token for client ID {ClientId} from L1 cache with cache key {CacheKey}, it will expire in {TimeToLive}")]
     public static partial void SuccessfullyReadTokenFromL1Cache(this ILogger logger, string clientId, string cacheKey, TimeSpan timeToLive);
 
-    [LoggerMessage(3, LogLevel.Debug, "Successfully read token for client ID {ClientId} from L2 cache with cache key {CacheKey}, will expire in {TimeToLive}")]
+    [LoggerMessage(3, LogLevel.Debug, "Successfully read token for client ID {ClientId} from L2 cache with cache key {CacheKey}, it will expire in {TimeToLive}")]
     public static partial void SuccessfullyReadTokenFromL2Cache(this ILogger logger, string clientId, string cacheKey, TimeSpan timeToLive);
 
     [LoggerMessage(4, LogLevel.Warning, "Client credentials token cache should not be using an in-memory distributed cache implementation")]

--- a/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/LoggingExtensions.cs
+++ b/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/LoggingExtensions.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.Extensions.Logging;
+
+namespace Workleap.Extensions.Http.Authentication.ClientCredentialsGrant;
+
+internal static partial class LoggingExtensions
+{
+    // ClientCredentialsTokenCache
+    [LoggerMessage(1, LogLevel.Debug, "Caching token for client ID {ClientId} with cache key {CacheKey} for {CacheDuration}")]
+    public static partial void CachingToken(this ILogger logger, string clientId, string cacheKey, TimeSpan cacheDuration);
+
+    [LoggerMessage(2, LogLevel.Debug, "Successfully read token for client ID {ClientId} from L1 cache with cache key {CacheKey}, will expire in {TimeToLive}")]
+    public static partial void SuccessfullyReadTokenFromL1Cache(this ILogger logger, string clientId, string cacheKey, TimeSpan timeToLive);
+
+    [LoggerMessage(3, LogLevel.Debug, "Successfully read token for client ID {ClientId} from L2 cache with cache key {CacheKey}, will expire in {TimeToLive}")]
+    public static partial void SuccessfullyReadTokenFromL2Cache(this ILogger logger, string clientId, string cacheKey, TimeSpan timeToLive);
+
+    [LoggerMessage(4, LogLevel.Warning, "Client credentials token cache should not be using an in-memory distributed cache implementation")]
+    public static partial void DistributedCacheIsUsingInMemoryImplementation(this ILogger logger);
+
+    // ClientCredentialsTokenEndpointService
+    [LoggerMessage(5, LogLevel.Debug, "Requesting new token for client ID {ClientId}")]
+    public static partial void RequestingNewTokenForClient(this ILogger logger, string clientId);
+
+    // ClientCredentialsTokenManagementService
+    [LoggerMessage(6, LogLevel.Debug, "Requesting a token for client ID {ClientId} with caching behavior {CachingBehavior}")]
+    public static partial void RequestingTokenForClientWithCachingBehavior(this ILogger logger, string clientId, CachingBehavior cachingBehavior);
+
+    [LoggerMessage(7, LogLevel.Debug, "Scheduling background token refresh for client ID {ClientId} in {Delay}")]
+    public static partial void SchedulingBackgroundTokenRefresh(this ILogger logger, string clientId, TimeSpan delay);
+
+    [LoggerMessage(8, LogLevel.Debug, "Executing background token refresh for client ID {ClientId}")]
+    public static partial void ExecutingBackgroundTokenRefresh(this ILogger logger, string clientId);
+}

--- a/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/OnStartupTokenCacheBackgroundService.cs
+++ b/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/OnStartupTokenCacheBackgroundService.cs
@@ -86,9 +86,16 @@ internal sealed class OnStartupTokenCacheBackgroundService : BackgroundService
     {
         if (this._clientNames.Count > 0)
         {
-            var timeoutTask = Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
-            var completedTask = await Task.WhenAny(this._allTokensCachedSignal.Task, timeoutTask).ConfigureAwait(false);
-            await completedTask.ConfigureAwait(false);
+            try
+            {
+                var timeoutTask = Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+                var completedTask = await Task.WhenAny(this._allTokensCachedSignal.Task, timeoutTask).ConfigureAwait(false);
+                await completedTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+            {
+                throw new TimeoutException($"{nameof(OnStartupTokenCacheBackgroundService)} didn't complete its job in time");
+            }
         }
     }
 

--- a/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/TracingHelper.cs
+++ b/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/TracingHelper.cs
@@ -31,7 +31,7 @@ internal static class TracingHelper
     }
 
     [SuppressMessage("ReSharper", "ExplicitCallerInfoArgument", Justification = "We want a specific activity name, not the caller method name")]
-    public static Activity? StartBackgroundRefreshDetachedActivity(string clientId)
+    public static Activity? StartBackgroundRefreshActivity(string clientId)
     {
         var activity = ActivitySource.StartActivity(ActivityName, ActivityKind.Internal, parentId: null!);
 

--- a/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/TracingHelper.cs
+++ b/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/TracingHelper.cs
@@ -1,0 +1,46 @@
+﻿using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+
+namespace Workleap.Extensions.Http.Authentication.ClientCredentialsGrant;
+
+internal static class TracingHelper
+{
+    private const string ActivityName = "ClientCredentials";
+
+    private const string ClientIdTagName = "clientcredentials.clientid";
+
+    private static readonly Assembly Assembly = typeof(TracingHelper).Assembly;
+    private static readonly AssemblyName AssemblyName = Assembly.GetName();
+    private static readonly string AssemblyVersion = Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? AssemblyName.Version!.ToString();
+
+    private static readonly ActivitySource ActivitySource = new ActivitySource(AssemblyName.Name, AssemblyVersion);
+
+    [SuppressMessage("ReSharper", "ExplicitCallerInfoArgument", Justification = "We want a specific activity name, not the caller method name")]
+    public static Activity? StartAuthenticationActivity(string clientId)
+    {
+        var activity = ActivitySource.StartActivity(ActivityName);
+
+        if (activity != null)
+        {
+            activity.DisplayName = "Client credentials authenticate";
+            activity.SetTag(ClientIdTagName, clientId);
+        }
+
+        return activity;
+    }
+
+    [SuppressMessage("ReSharper", "ExplicitCallerInfoArgument", Justification = "We want a specific activity name, not the caller method name")]
+    public static Activity? StartBackgroundRefreshDetachedActivity(string clientId)
+    {
+        var activity = ActivitySource.StartActivity(ActivityName, ActivityKind.Internal, parentId: null!);
+
+        if (activity != null)
+        {
+            activity.DisplayName = "M2M background refresh";
+            activity.SetTag(ClientIdTagName, clientId);
+        }
+
+        return activity;
+    }
+}

--- a/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/TracingHelper.cs
+++ b/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/TracingHelper.cs
@@ -37,7 +37,7 @@ internal static class TracingHelper
 
         if (activity != null)
         {
-            activity.DisplayName = "M2M background refresh";
+            activity.DisplayName = "Client credentials background refresh";
             activity.SetTag(ClientIdTagName, clientId);
         }
 

--- a/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/TracingHelper.cs
+++ b/src/Workleap.Extensions.Http.Authentication.ClientCredentialsGrant/TracingHelper.cs
@@ -8,7 +8,7 @@ internal static class TracingHelper
 {
     private const string ActivityName = "ClientCredentials";
 
-    private const string ClientIdTagName = "clientcredentials.clientid";
+    private const string ClientIdTagName = "client_credentials.client_id";
 
     private static readonly Assembly Assembly = typeof(TracingHelper).Assembly;
     private static readonly AssemblyName AssemblyName = Assembly.GetName();


### PR DESCRIPTION
## Description of changes

The objectif of this PR is to improve troubleshooting related to token retrieval during client credentials authentication.

- Added logs at different places to understand if we use the cache properly, how long we cache the token, etc.
- Added activities to help searching M2M-related spans in distributed traces.
- Revamp of the integration test to simulate a more realistic distributed environment to help understand how we interact with L1/L2 cache.

The integration test revamp already revealed that the token background acquisition/refresh is a bit too agressive, it doesn't leverage the L2 cache when there's a token that still has a long lifetime.

It is best to review the code of the integration test in the IDE.

Logs can be enabled by setting the default level for the category Workleap.Extensions.Http.Authentication.ClientCredentialsGrant to Debug. For instance they can be published using the OpenTelemetry exporter:

```json
    "OpenTelemetry": {
      "LogLevel": {
        "Default": "Warning",
        "Workleap.Extensions.Http.Authentication.ClientCredentialsGrant": "Debug"
      }
    }
```

## Breaking changes

None

## QA screenshots

Authenticating an HTTP request with a token already in cache (no call to the identity provider is made)
![image](https://github.com/user-attachments/assets/92ad7c64-a2ae-42db-87f1-b986b643f563)

Authenticating an HTTP request - acquire a new token (a POST call is made - I had to disable the background token refresh to see it):
![image](https://github.com/user-attachments/assets/1e7ef7a2-ac4d-45e8-ae47-dde7388bafb3)

Background token refresh - detached span:
![image](https://github.com/user-attachments/assets/d7876dc3-87ed-4629-a7ca-b7cb2ce1f459)

New logs (simulated with a token that has a 30 seconds TTL and cache eviction 10 seconds prior to its expiration)
![image](https://github.com/user-attachments/assets/b65aeb51-6bd1-43c2-849f-983df341a195)


